### PR TITLE
fix: fix incorrect location of types files

### DIFF
--- a/packages/av-canvas/build.tsconfig.json
+++ b/packages/av-canvas/build.tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/__tests__/*", "demo"]
+  "exclude": ["src/**/__tests__/*", "demo"],
+  "include": ["src/**/*"]
 }

--- a/packages/av-recorder/build.tsconfig.json
+++ b/packages/av-recorder/build.tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/__tests__/*", "demo"]
+  "exclude": ["src/**/__tests__/*", "demo"],
+  "include": ["../../types/mp4box.d.ts", "src/**/*"]
 }


### PR DESCRIPTION
## 问题
`av-canvas` 和 `av-recorder` 两个项目打包的 types 文件目录有点问题，在 `dist/src` 目录下，而 `package.json` 中 `types` 配置的是 `dist` 目录下的文件，会导致使用时找不到声明文件的 ts 错误。
<img width="274" alt="iShot_2024-05-29_09 17 32" src="https://github.com/hughfenghen/WebAV/assets/1836701/056c0150-a69a-4a83-8158-74f285c42fbf">


<img width="345" alt="iShot_2024-05-29_09 22 52" src="https://github.com/hughfenghen/WebAV/assets/1836701/84f47b6b-abfd-49f2-8697-9a4865ff19b7">


<img width="774" alt="iShot_2024-05-29_09 16 53" src="https://github.com/hughfenghen/WebAV/assets/1836701/263271b6-1288-487e-89f7-283f6c88eda4">


## 修改
按照 `av-cliper` 项目的配置调整了下 `av-canvas` 和 `av-recorder` 两个项目的 `build.tsconfig.json`，解决该问题。