### PR TITLE
feat: support getting video width & height from webcam

### DIFF
--- a/packages/av-recorder/demo/record-usermedia.ts
+++ b/packages/av-recorder/demo/record-usermedia.ts
@@ -27,10 +27,7 @@ startEl?.addEventListener('click', () => {
     vEl.srcObject = mediaStream;
     vEl.play().catch(console.error);
 
-    recorder = new AVRecorder(recodeMS, {
-      width: 1280,
-      height: 720,
-    });
+    recorder = new AVRecorder(recodeMS);
     recorder.on('stateChange', (state) => {
       console.log('stateChange:', state);
     });

--- a/packages/av-recorder/src/types.ts
+++ b/packages/av-recorder/src/types.ts
@@ -14,7 +14,7 @@ export interface IWorkerOpts {
     height: number;
     expectFPS: number;
     codec: string;
-  };
+  } | null;
   audio: {
     codec: 'opus' | 'aac';
     sampleRate: number;


### PR DESCRIPTION
## 问题描述：
原先 AVRecorder 默认的视频宽高为 1280×720，demo中 getUserMedia 没有手动指定宽高的时候，我的 mac 默认拿的摄像头流的尺寸是 640×480，并不是16:9，导致保存的视频文件比例发生变化

## 解决方法：
初始化 AVRecorder 实例的时候，支持不传入宽高，在开始录制的时候，fallback 从 videoTrack settings 中获取实际流的宽高